### PR TITLE
fix: api가 두 번 호출되는 문제 해결 #4

### DIFF
--- a/src/components/main.js
+++ b/src/components/main.js
@@ -63,9 +63,9 @@ export default class Main extends Component {
   }
 
   setEvent() {
-    this.addEvent('click', 'li > a', (e) => {
-      const targetElement = e.target.closest('li');
+    this.addEvent('click', 'ul', (e) => {
       e.preventDefault();
+      const targetElement = e.target.closest('li');
       const articleId = targetElement.id;
       navigate(`/article/${articleId}`);
     });

--- a/src/core/Component.js
+++ b/src/core/Component.js
@@ -5,9 +5,12 @@ export default class Component {
 
   $state;
 
+  $attachedEventListeners;
+
   constructor($target, $props) {
     this.$target = $target;
     this.$props = $props;
+    this.$attachedEventListeners = [];
     this.setup();
     this.setEvent();
     this.render();
@@ -25,6 +28,13 @@ export default class Component {
    */
   mounted() {
     // 추상화를 위한 메서드
+  }
+
+  /**
+   * 컴포넌트가 언마운트 되었을 때의 설정
+   */
+  unmounted() {
+    this.removeEvent();
   }
 
   /**
@@ -66,9 +76,22 @@ export default class Component {
    * @param {*} callback
    */
   addEvent(eventType, selector, callback) {
-    this.$target.addEventListener(eventType, (event) => {
+    const listener = (event) => {
       if (!event.target.closest(selector)) return false;
       callback(event);
-    });
+    };
+    this.$target.addEventListener(eventType, listener);
+    this.$attachedEventListeners.push({ eventType, listener });
+  }
+
+  /**
+   * 이벤트 리스너 제거
+   */
+  removeEvent() {
+    for (let { eventType, listener } of this.$attachedEventListeners) {
+      this.$target.removeEventListener(eventType, listener);
+    }
+
+    this.$attachedEventListeners = [];
   }
 }

--- a/src/router.js
+++ b/src/router.js
@@ -11,6 +11,8 @@ const routes = [
 ];
 
 export default class Router extends Component {
+  currentComponent = null;
+
   findMatchedRoute() {
     return routes.find((route) => route.path.test(location.pathname));
   }
@@ -21,7 +23,11 @@ export default class Router extends Component {
    */
   navigate() {
     const containerPage = this.findMatchedRoute()?.element || NotFound;
-    new containerPage(this.$container);
+    if (this.currentComponent) {
+      this.currentComponent.unmounted();
+    }
+
+    this.currentComponent = new containerPage(this.$container);
   }
 
   /**


### PR DESCRIPTION
## issue number
#4 

## key changes
api가 반복적으로 호출되는 문제를 해결했어요.

### 원인
main.js에 있는 이벤트 리스너가 제거되지 않고 있었어요.

### 해결
공통 컴포넌트에 unmount 메서드를 추가하고, 이벤트 리스너를 제거하는 로직을 추가했어요.

라우터에 컴포넌트를 렌더링 하기 전 기존 컴포넌트를 unmount시켜요.

## to reviewer
